### PR TITLE
Fix port parsing for configuring api

### DIFF
--- a/PythonRegression/util/test_logic/api_test_logic.py
+++ b/PythonRegression/util/test_logic/api_test_logic.py
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 def prepare_api_call(nodeName):
     logger.info('Preparing api call')
-    host = world.machine[nodeName]['host']
-    port = world.machine[nodeName]['ports']['api']
-    address ="http://"+ host + ":" + port
+    host = world.machine['nodes'][nodeName]['host']
+    port = world.machine['nodes'][nodeName]['ports']['api']
+    address ="http://"+ host + ":" + str(port)
     api = Iota(address)
     logger.info('API call prepared for %s',address)
     return api


### PR DESCRIPTION
This PR removes the `prepare_api_call()` method from `api_test_steps.py` and replaces it with the correct method in `api_test_logic.py`. The parsing has been corrected to pull from the `output.yml` file correctly now.