### PR TITLE
Minor bug fix for interrupt

### DIFF
--- a/PythonRegression/tests/features/steps/api_test_steps.py
+++ b/PythonRegression/tests/features/steps/api_test_steps.py
@@ -169,6 +169,8 @@ def generate_transaction_and_attach(step,node):
     trunk = str(gtta['trunkTransaction'])
 
     sent = api.attach_to_tangle(trunk,branch,[trytes],9)
+    world.responses['attachToTangle'] = {}
+    world.responses['attachToTangle'][node] = sent
     logger.info('Transaction Sent')
 
     setattr(static_vals, "TEST_STORE_TRANSACTION", sent.get('trytes'))


### PR DESCRIPTION
There is a missing response storage for the interrupt test. When generating a transaction, the response is not stored in world, this PR fixes that. 