### PR TITLE
Update DB for stitching tests

### DIFF
--- a/PythonRegression/tests/features/machine4/config.yml
+++ b/PythonRegression/tests/features/machine4/config.yml
@@ -1,5 +1,5 @@
 defaults: &db_1
-  db: https://s3.amazonaws.com/iota-db-files/dbs/machine4/testnet-testdb.tar
+  db: https://s3.eu-central-1.amazonaws.com/iotaledger-dbfiles/dev/Stitching_tests_db.tar
   db_checksum: ac987dc8e61e37d6420e78da18c4cf94671f51e8014b4dd593f36bbd4fb0cfc1
   iri_args: ['--testnet-coordinator',
   'EFPNKGPCBXXXLIBYFGIGYBYTFFPIOQVNNVVWTTIYZO9NFREQGVGDQQHUUQ9CLWAEMXVDFSSMOTGAHVIBH',


### PR DESCRIPTION
Moved the Db for the stitching test over to the IF db-files s3 bucket. The other db's have been moved as well, but the updates will be in their appropriate PR's. 